### PR TITLE
Make DefaultProblem implement the error interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
  - 1.5
  - 1.6
  - 1.6.2
- - release
+ - 1.7
  - tip
 
 script:

--- a/problem.go
+++ b/problem.go
@@ -2,6 +2,7 @@ package problems
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -24,6 +25,7 @@ const (
 type Problem interface {
 	ProblemType() (*url.URL, error)
 	ProblemTitle() string
+	Error() string
 }
 
 // StatusProblem is the interface describing a problem with an associated
@@ -118,4 +120,11 @@ func (p *DefaultProblem) ProblemTitle() string {
 // interface, returning the Status code for this problem
 func (p *DefaultProblem) ProblemStatus() int {
 	return p.Status
+}
+
+// Implement Error() so it can satisfy the default error Interface
+// It returns a string in the form of:
+//     <Title> (Status) - <Detail>
+func (p *DefaultProblem) Error() string {
+	return fmt.Sprintf("%s (%d) - %s", p.Title, p.Status, p.Detail)
 }

--- a/problem_test.go
+++ b/problem_test.go
@@ -42,6 +42,10 @@ func (p badProblemType) ProblemTitle() string {
 	return "something valid"
 }
 
+func (p badProblemType) Error() string {
+	return ""
+}
+
 type badProblemTitle struct{}
 
 func (p badProblemTitle) ProblemType() (*url.URL, error) {
@@ -49,6 +53,10 @@ func (p badProblemTitle) ProblemType() (*url.URL, error) {
 }
 
 func (p badProblemTitle) ProblemTitle() string {
+	return ""
+}
+
+func (p badProblemTitle) Error() string {
 	return ""
 }
 
@@ -116,5 +124,22 @@ func TestCreditProblem(t *testing.T) {
 	err = ValidateProblem(problem)
 	if err != nil {
 		t.Errorf("problem is not valid")
+	}
+}
+
+func TestErrorInterface(t *testing.T) {
+	var i interface{} = &DefaultProblem{Type: DefaultURL,
+		Status: 401,
+		Title:  http.StatusText(http.StatusUnauthorized),
+		Detail: "Detail Message.",
+	}
+	p, ok := i.(error)
+	if !ok {
+		t.Errorf("DefaultProblem does not implement error interface")
+	}
+
+	expected := http.StatusText(http.StatusUnauthorized) + " (401) - Detail Message."
+	if p.Error() != expected {
+		t.Errorf("Error message was not what we were expecting. Expected '%s', got '%s'", expected, p.Error())
 	}
 }


### PR DESCRIPTION
I added the Error() function to satisfy the error interface. Error string should be `<Title> (Status) - <Detail>`

I also had to modify badProblemType and badProblemTitle structs in the tests to add an Error() function. They currently return an empty string because those tests don't use it.