### PR TITLE
add handlers for StatusProblem interface that set the HTTP response code

### DIFF
--- a/web.go
+++ b/web.go
@@ -23,3 +23,27 @@ func XMLProblemHandler(p Problem) http.HandlerFunc {
 		xml.NewEncoder(w).Encode(p)
 	}
 }
+
+// StatusProblemHandler returns an http.HandlerFunc which writes a provided
+// problem to an http.ResponseWriter as JSON with the status code
+func StatusProblemHandler(p StatusProblem) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", ProblemMediaType)
+		if p.ProblemStatus() != 0 {
+			w.WriteHeader(p.ProblemStatus())
+		}
+		json.NewEncoder(w).Encode(p)
+	}
+}
+
+// XMLStatusProblemHandler returns an http.HandlerFunc which writes a provided
+// problem to an http.ResponseWriter as XML with the status code
+func XMLStatusProblemHandler(p StatusProblem) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", ProblemMediaTypeXML)
+		if p.ProblemStatus() != 0 {
+			w.WriteHeader(p.ProblemStatus())
+		}
+		xml.NewEncoder(w).Encode(p)
+	}
+}

--- a/web_test.go
+++ b/web_test.go
@@ -63,6 +63,42 @@ func TestJSONProblems(t *testing.T) {
 	}
 }
 
+func TestJSONStatusProblems(t *testing.T) {
+	notFound := NewStatusProblem(404)
+	notFound.Detail = "That thing doesn't exist."
+
+	server := testServer(StatusProblemHandler(notFound))
+	defer server.Close()
+
+	w, err := getResponse("/", server)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if w.StatusCode != notFound.Status {
+	    t.Errorf("Expected HTTP status code to be %d, got %d", notFound.Status, w.StatusCode)
+	}
+
+	decoder := json.NewDecoder(w.Body)
+	var response DefaultProblem
+	err = decoder.Decode(&response)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if response.Status != notFound.Status {
+		t.Errorf("Expected response Status to be %d, but got %d", notFound.Status, response.Status)
+	}
+
+	if response.Title != notFound.Title {
+		t.Errorf("Expected response Title to be %q, but got %q", notFound.Title, response.Title)
+	}
+
+	if response.Detail != notFound.Detail {
+		t.Errorf("Expected response Detail to be %q, but got %q", notFound.Detail, response.Detail)
+	}
+}
+
 func TestXMLProblems(t *testing.T) {
 	notFound := NewStatusProblem(404)
 	notFound.Detail = "That thing doesn't exist."
@@ -73,6 +109,42 @@ func TestXMLProblems(t *testing.T) {
 	w, err := getResponse("/", server)
 	if err != nil {
 		t.Error(err)
+	}
+
+	decoder := xml.NewDecoder(w.Body)
+	var response DefaultProblem
+	err = decoder.Decode(&response)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if response.Status != notFound.Status {
+		t.Errorf("Expected response Status to be %d, but got %d", notFound.Status, response.Status)
+	}
+
+	if response.Title != notFound.Title {
+		t.Errorf("Expected response Title to be %q, but got %q", notFound.Title, response.Title)
+	}
+
+	if response.Detail != notFound.Detail {
+		t.Errorf("Expected response Detail to be %q, but got %q", notFound.Detail, response.Detail)
+	}
+}
+
+func TestXMLStatusProblems(t *testing.T) {
+	notFound := NewStatusProblem(404)
+	notFound.Detail = "That thing doesn't exist."
+
+	server := testServer(XMLStatusProblemHandler(notFound))
+	defer server.Close()
+
+	w, err := getResponse("/", server)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if w.StatusCode != notFound.Status {
+	    t.Errorf("Expected HTTP status code to be %d, got %d", notFound.Status, w.StatusCode)
 	}
 
 	decoder := xml.NewDecoder(w.Body)


### PR DESCRIPTION
The existing handlers do not call WriteHeaders so the HTTP status always 200. This change adds handlers for the StatusProblem interface that return the HTTP status code matching that of the problem.