### PR TITLE
Fix docs remove mentions to default problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ package main
 
 import "github.com/moogar0880/problems"
 
-func NoSuchUser() *problems.DefaultProblem {
+func NoSuchUser() *problems.Problem {
 	nosuch := problems.NewStatusProblem(404)
 	nosuch.Detail = "Sorry, that user does not exist."
 	return nosuch
@@ -158,7 +158,7 @@ var Unauthorized = problems.NewStatusProblem(401)
 
 func main() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/secrets", problems.StatusProblemHandler(Unauthorized))
+	mux.HandleFunc("/secrets", problems.ProblemHandler(Unauthorized))
 
 	server := http.Server{Handler: mux, Addr: ":8080"}
 	server.ListenAndServe()

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# problems
-Problems is an RFC-7807 and RFC-9457 compliant library for describing HTTP 
-errors. For more information see [RFC-9457](https://tools.ietf.org/html/rfc9457), 
-and it's predecessor [RFC-7807](https://tools.ietf.org/html/rfc7807).
+# Problems
+
+Problems is an RFC-7807 and RFC-9457 compliant library for describing HTTP errors.
+For more information see [RFC-9457](https://tools.ietf.org/html/rfc9457), and it's predecessor [RFC-7807](https://tools.ietf.org/html/rfc7807).
 
 [![Build Status](https://travis-ci.org/moogar0880/problems.svg?branch=master)](https://travis-ci.org/moogar0880/problems)
 [![Go Report Card](https://goreportcard.com/badge/github.com/moogar0880/problems)](https://goreportcard.com/report/github.com/moogar0880/problems)
 [![GoDoc](https://godoc.org/github.com/moogar0880/problems?status.svg)](https://godoc.org/github.com/moogar0880/problems)
 
 ## Usage
+
 The problems library exposes an assortment of types to aid HTTP service authors
 in defining and using HTTP Problem detail resources.
 
 ### Predefined Errors
+
 You can define basic Problem details up front by using the `NewStatusProblem`
 function
 
@@ -39,6 +41,7 @@ Which, when served over HTTP as JSON will look like the following:
 ```
 
 ### Detailed Errors
+
 New errors can also be created a head of time, or on the fly like so:
 
 ```go
@@ -47,9 +50,9 @@ package main
 import "github.com/moogar0880/problems"
 
 func NoSuchUser() *problems.Problem {
-	nosuch := problems.NewStatusProblem(404)
-	nosuch.Detail = "Sorry, that user does not exist."
-	return nosuch
+    nosuch := problems.NewStatusProblem(404)
+    nosuch.Detail = "Sorry, that user does not exist."
+    return nosuch
 }
 ```
 
@@ -65,6 +68,7 @@ Which, when served over HTTP as JSON will look like the following:
 ```
 
 ### Extended Errors
+
 The specification for these HTTP problems was designed to allow for arbitrary
 expansion of the problem resources. This can be accomplished through this
 library by either embedding the `Problem` struct in your extension type:
@@ -75,7 +79,7 @@ package main
 import "github.com/moogar0880/problems"
 
 type CreditProblem struct {
-	problems.Problem
+    problems.Problem
 
     Balance  float64  `json:"balance"`
     Accounts []string `json:"accounts"`
@@ -100,24 +104,24 @@ Or by using the `problems.ExtendedProblem` type:
 package main
 
 import (
-	"net/http"
+    "net/http"
 
-	"github.com/moogar0880/problems"
+    "github.com/moogar0880/problems"
 )
 
 type CreditProblemExt struct {
-	Balance  float64  `json:"balance"`
-	Accounts []string `json:"accounts"`
+    Balance  float64  `json:"balance"`
+    Accounts []string `json:"accounts"`
 }
 
 func main() {
-	problems.NewExt[CreditProblemExt]().
-		WithStatus(http.StatusForbidden).
-		WithDetail("Your account does not have sufficient funds to complete this transaction").
-		WithExtension(CreditProblemExt{
+    problems.NewExt[CreditProblemExt]().
+        WithStatus(http.StatusForbidden).
+        WithDetail("Your account does not have sufficient funds to complete this transaction").
+        WithExtension(CreditProblemExt{
             Balance:  30,
             Accounts: []string{"/account/12345", "/account/67890"},
-	    })
+        })
 }
 ```
 
@@ -129,13 +133,14 @@ Which, when served over HTTP as JSON will look like the following:
    "title": "Unauthorized",
    "status": 401, 
    "extensions": {
-	   "balance": 30,
-	   "accounts": ["/account/12345", "/account/67890"]    
+       "balance": 30,
+       "accounts": ["/account/12345", "/account/67890"]    
    }
 }
 ```
 
 ## Serving Problems
+
 Additionally, RFC-7807 defines two new media types for problem resources,
 `application/problem+json"` and `application/problem+xml`. This library defines
 those media types as the constants `ProblemMediaType` and
@@ -149,7 +154,7 @@ functioning `HandlerFunc` that will server that error.
 package main
 
 import (
-	"net/http"
+    "net/http"
 
     "github.com/moogar0880/problems"
 )
@@ -157,10 +162,10 @@ import (
 var Unauthorized = problems.NewStatusProblem(401)
 
 func main() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/secrets", problems.ProblemHandler(Unauthorized))
+    mux := http.NewServeMux()
+    mux.HandleFunc("/secrets", problems.ProblemHandler(Unauthorized))
 
-	server := http.Server{Handler: mux, Addr: ":8080"}
-	server.ListenAndServe()
+    server := http.Server{Handler: mux, Addr: ":8080"}
+    server.ListenAndServe()
 }
 ```

--- a/problem.go
+++ b/problem.go
@@ -61,7 +61,7 @@ func NewStatusProblem(status int) *Problem {
 	return New().WithTitle(http.StatusText(status)).WithStatus(status)
 }
 
-// NewDetailedProblem returns a new DefaultProblem with a Detail string set for
+// NewDetailedProblem returns a new Problem with a Detail string set for
 // a more detailed explanation of the problem being returned.
 func NewDetailedProblem(status int, details string) *Problem {
 	return NewStatusProblem(status).WithDetail(details)


### PR DESCRIPTION
the readme and godocs have mentions to old names, this make the current migration to v1 a little bit confused.

I think I fix the doc, could you please check?

Thanks